### PR TITLE
Fixes bug where flushing path queue during move will cause crash

### DIFF
--- a/Part_4/mobot_pub_des_state/src/pub_des_state.cpp
+++ b/Part_4/mobot_pub_des_state/src/pub_des_state.cpp
@@ -181,7 +181,9 @@ void DesStatePublisher::pub_next_state() {
             if (traj_pt_i_ >= npts_traj_) {
                 motion_mode_ = DONE_W_SUBGOAL; //if so, indicate we are done
                 seg_end_state_ = des_state_vec_.back(); // last state of traj
-                path_queue_.pop(); // done w/ this subgoal; remove from the queue 
+                if (!path_queue.empty()) { 
+                    path_queue_.pop(); // done w/ this subgoal; remove from the queue 
+                }
                 ROS_INFO("reached a subgoal: x = %f, y= %f",current_pose_.pose.position.x,
                         current_pose_.pose.position.y);
             }


### PR DESCRIPTION
If you flush a path_queue during a move, the path_queue will be emptied. Then when the move is finished, the program will try to pop another item. This causes the program to crash. This adds a check to make sure the path_queue isn't empty before popping the item and declaring the subgoal is finished.