### PR TITLE
fixed sgn function

### DIFF
--- a/Part_4/traj_builder/src/traj_builder.cpp
+++ b/Part_4/traj_builder/src/traj_builder.cpp
@@ -71,10 +71,10 @@ double TrajBuilder::sat(double x) {
 
 //signum function: returns the sign of a value
 double TrajBuilder::sgn(double x) {
-    if (x > 1.0) {
+    if (x > 0.0) {
         return 1.0;
     }
-    if (x< -1.0) {
+    if (x< 0.0) {
         return -1.0;
     }
     return 0.0;


### PR DESCRIPTION
The sign function was returning 0 for values between -1 and 1 which was causing the robot to not be able to turn for angles less than 1 radian.