### PR TITLE
Update minimal_robot_w_jnt_ctl.launch

### DIFF
--- a/Part_2/minimal_robot_description/minimal_robot_w_jnt_ctl.launch
+++ b/Part_2/minimal_robot_description/minimal_robot_w_jnt_ctl.launch
@@ -4,9 +4,14 @@
   <param name="robot_description" 
      textfile="$(find minimal_robot_description)/minimal_robot_description_w_jnt_ctl.urdf"/>
 
+  <!-- Start Gazebo -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch" />
+  
   <!-- Spawn a robot into Gazebo -->
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" 
      args="-param robot_description -urdf -model one_DOF_robot" />
+
+
   
   <!--start up the controller plug-ins via the controller manager -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"


### PR DESCRIPTION
Including empty world command to start gazebo. Could add all the common default arguments. But without this line, gazebo has to be started separately.